### PR TITLE
Fix GitHub actions workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,7 +26,7 @@ jobs:
     name: RawkSD
     runs-on: ubuntu-latest
     container:
-      image: devkitpro/devkitppc:20210726
+      image: devkitpro/devkitppc:20250727
     steps:
     - uses: actions/checkout@v5
     - run: |


### PR DESCRIPTION
Merging into the "ios37-fix" branch since that will fix some compile issues anyways.

If I find any more issues I'll make a new branch to fix it, ~~but it looks like the action [does follow the instructions for setting up devkitPro pacman correctly](https://devkitpro.org/wiki/devkitPro_pacman) and it 403's.~~ 
Edit: Seems that was a fluke.