### PR TITLE
Riivolution Wii Mini IOS37 check fix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,41 +1,44 @@
 on:
 - push
 - pull_request
+- workflow_dispatch
 
 jobs:
   riiv:
     name: Riivolution
     runs-on: ubuntu-latest
     container:
-      image: devkitpro/devkitppc:20210726
+      image: devkitpro/devkitppc:20250727
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
     - run: |
         dpkg --add-architecture i386
         apt-get update && apt-get install -y --no-install-recommends g++ libgcc1:i386 zlib1g:i386
       name: dependencies
     - run: make launcher -j
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v5
       with:
         name: riivolution
         path: launcher/riiv.zip
+        include-hidden-files: true
     - run: make riifs -j
   rawk:
     name: RawkSD
     runs-on: ubuntu-latest
     container:
-      image: devkitpro/devkitppc:20210726
+      image: devkitpro/devkitppc:20250727
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
     - run: |
         dpkg --add-architecture i386
         apt-get update && apt-get install -y --no-install-recommends g++ libgcc1:i386 zlib1g:i386 python3 python3-yaml
       name: dependencies
     - run: make rawksd -j
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v5
       with:
         name: rawksd
         path: rawksd/rawk.zip
+        include-hidden-files: true
   msys2:
     name: Windows MSYS2
     runs-on: windows-latest
@@ -60,41 +63,46 @@ jobs:
         install: >-
           base-devel gcc python-yaml zip unzip python
           wii-dev ppc-portlibs wii-portlibs devkitARM
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
     - run: |
         DEVKITPRO=/opt/devkitpro DEVKITPPC=$DEVKITPRO/devkitPPC DEVKITARM=$DEVKITPRO/devkitARM \
         make launcher -j
       name: make launcher
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v5
       with:
         name: msys2-riivolution
         path: launcher/riiv.zip
+        include-hidden-files: true
     - run: |
         PYTHON=/usr/bin/python3.exe \
         DEVKITPRO=/opt/devkitpro DEVKITPPC=$DEVKITPRO/devkitPPC DEVKITARM=$DEVKITPRO/devkitARM \
         make rawksd -j
       name: make rawksd
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v5
       with:
         name: msys2-rawksd
         path: rawksd/rawk.zip
+        include-hidden-files: true
   mingw:
     name: Windows Mingw
     runs-on: windows-latest
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v5
     - run: make riifs
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v5
       with:
         name: mingw32-riifs
         path: riifs/server-c/riifs.exe
+        include-hidden-files: true
     - run: make -C stripios
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v5
       with:
         name: mingw32-stripios
         path: stripios/stripios.exe
+        include-hidden-files: true
     - run: make -C launcher/dollz3
-    - uses: actions/upload-artifact@v2
+    - uses: actions/upload-artifact@v5
       with:
         name: mingw32-dol2elf
         path: launcher/dollz3/dol2elf.exe
+        include-hidden-files: true

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Information archives:
 
 - [devkitPPC and devkitARM](https://devkitpro.org/wiki/Getting_Started)
 	- `dkp-pacman -S wii-dev ppc-portlibs wii-portlibs devkitARM`
+- ppc-libogg and ppc-libvorbisidec
+	- `dkp-pacman -S ppc-libogg ppc-libvorbisidec`
 - a build environment for your host with GNU Make, some coreutils, and a C++ compiler
 	- on Windows, devkitPro supplies and requires this via [MSYS2](https://www.msys2.org/)
 - Python 3.x and python-yaml or pyyaml (only for rawksd)

--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@ Information archives:
 
 - [devkitPPC and devkitARM](https://devkitpro.org/wiki/Getting_Started)
 	- `dkp-pacman -S wii-dev ppc-portlibs wii-portlibs devkitARM`
-- ppc-libogg and ppc-libvorbisidec
-	- `dkp-pacman -S ppc-libogg ppc-libvorbisidec`
+- ppc-libogg, ppc-libvorbisidec and ppc-freetype
+	- `dkp-pacman -S ppc-libogg ppc-libvorbisidec ppc-freetype`
 - a build environment for your host with GNU Make, some coreutils, and a C++ compiler
 	- on Windows, devkitPro supplies and requires this via [MSYS2](https://www.msys2.org/)
 - Python 3.x and python-yaml or pyyaml (only for rawksd)

--- a/launcher/include/haxx.h
+++ b/launcher/include/haxx.h
@@ -77,7 +77,7 @@ int seeprom_write(const void *src, unsigned int offset, unsigned int size);
 int seeprom_read(void *dst, unsigned int offset, unsigned int size);
 
 #define HAXX_IOS 0x0000000100000025ULL
-#define HAXX_IOS_MAXIMUM 5919
+#define HAXX_IOS_MAXIMUM 31519
 #define HAXX_IOS_MINIMUM 3869
 
 //#define DEBUG_HAXX 1

--- a/launcher/source/haxx.cpp
+++ b/launcher/source/haxx.cpp
@@ -1573,8 +1573,12 @@ static bool do_exploit()
 
 	printf("Grabbin' HAXX\n");
 
-	if (IOS_GetVersion() != (u32)HAXX_IOS /* || (ios_rev != 5663 && ios_rev != 5662 && ios_rev != 3869 && ios_rev != 5919) */)
+	int macaddr_fd = IOS_Open("/title/00000001/00000002/data/macaddr.bin", IPC_OPEN_READ);
+	if (IOS_GetVersion() != (u32)HAXX_IOS || (ios_rev != 5663 && ios_rev != 5662 && ios_rev != 3869 && ios_rev != 5919 && (ios_rev != 31519 && macaddr_fd >= 0)))
 	{
+		if (macaddr_fd >= 0) {
+			IOS_Close(macaddr_fd);
+		}
 		printf("Wrong IOS version (%08x). Update IOS%d to the latest version.\n", read32(0x3140), (u32)HAXX_IOS);
 		return false;
 	}

--- a/launcher/source/haxx.cpp
+++ b/launcher/source/haxx.cpp
@@ -1573,7 +1573,7 @@ static bool do_exploit()
 
 	printf("Grabbin' HAXX\n");
 
-	if (IOS_GetVersion() != (u32)HAXX_IOS || (ios_rev != 5663 && ios_rev != 5662 && ios_rev != 3869 && ios_rev != 5919))
+	if (IOS_GetVersion() != (u32)HAXX_IOS /* || (ios_rev != 5663 && ios_rev != 5662 && ios_rev != 3869 && ios_rev != 5919) */)
 	{
 		printf("Wrong IOS version (%08x). Update IOS%d to the latest version.\n", read32(0x3140), (u32)HAXX_IOS);
 		return false;

--- a/launcher/source/init.cpp
+++ b/launcher/source/init.cpp
@@ -149,7 +149,7 @@ void Initialise()
 			if (!PressA())
 				exit(0);
 			approach = INSTALL_APPROACH_UPDATE;
-		} else if (2 < 1) {
+		} else if (IOS_GetRevision() > HAXX_IOS_MAXIMUM) {
 			// Either cIOScrap (which will make the downgrade exploit fail) or a future update
 			printf("\tIOS%d must be downgraded to continue. Do you want to attempt this now?\n", (u32)HAXX_IOS);
 			if (!PressA())

--- a/launcher/source/init.cpp
+++ b/launcher/source/init.cpp
@@ -149,7 +149,7 @@ void Initialise()
 			if (!PressA())
 				exit(0);
 			approach = INSTALL_APPROACH_UPDATE;
-		} else if (IOS_GetRevision() > HAXX_IOS_MAXIMUM) {
+		} else if (2 < 1) {
 			// Either cIOScrap (which will make the downgrade exploit fail) or a future update
 			printf("\tIOS%d must be downgraded to continue. Do you want to attempt this now?\n", (u32)HAXX_IOS);
 			if (!PressA())

--- a/launcher/source/installer.cpp
+++ b/launcher/source/installer.cpp
@@ -262,7 +262,7 @@ static bool FakesignTMD(signed_blob* blob)
 	tmd* meta = (tmd*)SIGNATURE_PAYLOAD(blob);
 	u32 size = TMD_SIZE(meta);
 	for(u32 fill = 0; fill < 0xFFFF; fill++) {
-		meta->fill2 = fill;
+		meta->fill3 = fill;
 		sha1 hash; SHA1((u8*)meta, size, hash);
 
 		if (hash[0] == 0)

--- a/libios/include/gctypes.h
+++ b/libios/include/gctypes.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stdbool.h>
+
 #ifdef __cplusplus
    extern "C" {
 #endif
@@ -36,8 +38,8 @@ typedef s32 ostimer_t; // ipc timer
 
 // bool is a standard type in cplusplus, but not in c.
 #ifndef __cplusplus
-typedef u8 bool;
-enum { false, true };
+//typedef u8 bool;
+//enum { false, true };
 #endif
 
 typedef unsigned int BOOL;


### PR DESCRIPTION
On launch, Riivolution compares against a set list of known IOS37 revisions. The Wii Mini uses v31519, which is not recognized, so it complains and asks you to either downgrade or update to a supported revision.

[The current mainstream modification](https://oscwii.org/library/app/riivolution-mini) fixes this by patching out the checks entirely (103f76f02d015b978de6f7ae9557dd70c0fdcfe3 + 00e7f971e70bd826b8f0b7175e07a61d59ebbc3e). I *really* don't like that, because this problem has happened before and was fixed correctly in 2013: the Wii U's Wii Mode (or vWii) use v5919. It was solved in commit adf853889c4150708de7c1b4413a8e1b6e8259f9: in addition to all the other Wii U-specific code, it added v5919 as a supported revision in this check.

In contrast, v31519 is *only* used on the Wii Mini. [We have known ways to detect if a Wii Mini is being used](https://github.com/DacoTaco/priiloader/issues/220#issuecomment-569325910), so I want to check for if v31519 is running *on a Wii Mini* alongside every other condition. Since we've already been using the current mainstream modification this long, I think it's reasonable to assume that unlike the Wii U, no further code changes are necessary for compatibility.

I would apply similar logic to v5919 (check if it's running *on a Wii U*), but that revision number was also used on some Wii Family Edition consoles. If that wasn't the case, it wouldn't be as annoying to implement since there is quite a bit of "is this a Wii U?" code scattered around both Riivolution and RawkSD. I don't want to cause any new incompatibility that isn't already there.